### PR TITLE
fix: change default origin to deepin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+base-files (23.1-4) unstable; urgency=medium
+
+  * change origin to deepin
+
+ -- Chang Yang <yangchang@deepin.org>  Tue, 17 Oct 2023 20:15:22 +0800
+
 base-files (23.1-3) unstable; urgency=medium
 
   * add debian_version.

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ ifeq ($(DEB_HOST_GNU_SYSTEM),gnu)
   OSNAME=GNU/Hurd
 endif
 
-VENDORFILE = debian
+VENDORFILE = deepin
 DESTDIR = debian/base-files
 
 %:


### PR DESCRIPTION
`cups-filter` prints wrong test pages logo