### PR TITLE
fix: 默认将 /var/local 设为 root:root 和 755 权限

### DIFF
--- a/debian/2775-dirs
+++ b/debian/2775-dirs
@@ -1,1 +1,0 @@
-var/local

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+base-files (25-6deepin5) unstable; urgency=medium
+
+  * Make /var/local to be root:root and 755 by default on new installs.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Thu, 21 May 2026 16:23:08 +0800
+
 base-files (25-6deepin4) unstable; urgency=medium
 
   * Delete the link/lib64 if the/etc/lib64 directory does not exist.

--- a/debian/rules
+++ b/debian/rules
@@ -71,10 +71,8 @@ override_dh_compress:
 
 override_dh_fixperms:
 	dh_fixperms
-	cd debian/base-files && chown root:staff   var/local
 	cd debian/base-files && chmod 755  `find . -type d`
 	cd debian/base-files && chmod 1777 `cat ../1777-dirs`
-	cd debian/base-files && chmod 2775 `cat ../2775-dirs`
 	cd debian/base-files && chmod 700 root
 
 override_dh_installdeb:


### PR DESCRIPTION
Make /var/local to be root:root and 755 by default on new installs.

跟随上游 13.7 版本，缺省使得 /var/local 是 root:root 755，去掉其 sgid 权限

Log: 删除 2775-dirs 及 rules 中 var/local 相关 sgid 权限设置
Influence: 新安装系统的 /var/local 目录权限